### PR TITLE
use external parameter to replace the in-file variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /sno-manual-helper.iml
 pull_secret.json
+/temp/rhcos-live.iso
+/temp/oc-client.tar.gz
+./build/*.iso
+/bin/oc
+/bin/openshift-install
+/assets/99_workload_partitioning.yaml
+/assets/10_inplace_dns.yaml

--- a/00_extract_tools_from_release.sh
+++ b/00_extract_tools_from_release.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-OCP_RELEASE=${OCP_RELEASE:-'stable-4.9'}
+OCP_RELEASE=$1; shift
+
+if [ -z "$OCP_RELEASE" ]
+then
+  OCP_RELEASE='stable-4.9'
+fi
+
 LOCAL_SECRET_JSON=./pull_secret.json
 
 OCP_RELEASE_VERSION=$(curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_RELEASE}/release.txt | grep 'Version:' | awk -F ' ' '{print $2}')

--- a/02_generate_workloadpartitioning_config.sh
+++ b/02_generate_workloadpartitioning_config.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-CPUSET="changeme"
 
-if [ "${CPUSET}" == "changeme" ]
+CPUSET=$1; shift
+
+if [ -z "$CPUSET" ]
 then
-  echo "Edit this script and change CPUSET variable value"
-  exit 1
+    echo "Run the script like ./02_generate_workloadpartitioning_config.sh <CPUSET>, for example ./02_generate_workloadpartitioning_config.sh 0-3,16-19"
+    exit 1
 fi
 
 cat <<EOF > assets/99_workload_partitioning.yaml

--- a/03_generate_inplacedns_config.sh
+++ b/03_generate_inplacedns_config.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-NODEIP="changeme"
+NODEIP=$1; shift
 
-if [ "${NODEIP}" == "changeme" ]
+if [ -z "$NODEIP" ]
 then
-  echo "Edit this script and change NODEIP variable value"
-  exit 1
+    echo "Run the script like ./03_generate_inplacedns_config.sh <your SNO node IP>, for example: ./03_generate_inplacedns_config.sh 10.19.142.235"
+    exit 1
 fi
 
 cat <<EOF > assets/10_inplace_dns.yaml

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ You are going to install OpenShift 4.9.5
 <omitted>
 ```
 
-or to install a particular release, OCP_RELEASE can be any version under [link](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/), for example ‘stable-4.8’, ‘4.8.12’, ‘4.9.4’, ‘latest’ etc. like 4.9.4 in below example:
+or to install a particular release under [link](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/), for example ‘stable-4.8’, ‘4.8.12’, ‘4.9.4’, ‘latest’ etc. like 4.9.4 in below example:
 
 ```shell
-$ OCP_RELEASE=4.9.4 ./00_extract_tools_from_release.sh
+$ ./00_extract_tools_from_release.sh 4.9.4
 You are going to install OpenShift 4.9.4
 <omitted>
 
@@ -37,20 +37,25 @@ rhcos-live.iso
 
 ```
 
-Edit 02_generate_workloadpartitioning_config.sh to set CPUSET, then:
+Run 02_generate_workloadpartitioning_config.sh to set reserved CPUSET:
 
 ```shell
 $ ./02_generate_workloadpartitioning_config.sh
+Run the script like ./02_generate_workloadpartitioning_config.sh <CPUSET>, for example ./02_generate_workloadpartitioning_config.sh 0-3,16-19
+$ ./02_generate_workloadpartitioning_config.sh 0-3,16-19
 $ ls -1 assets/
 99_workload_partitioning.yaml
 install-config.yaml
 
 ```
 
-Edit the 03_generate_inplacedns_config.sh script and edit the NODEIP variable, then:
+Run 03_generate_inplacedns_config.sh script to setup the in-place DNS resolution:
 
 ```shell
-$ ./03_generate_inplacedns_config.sh
+$./03_generate_inplacedns_config.sh 
+Run the script like ./03_generate_inplacedns_config.sh <your SNO node IP>, for example: ./03_generate_inplacedns_config.sh 10.19.142.235
+
+$ ./03_generate_inplacedns_config.sh 10.19.142.235
 $ ls -1 assets/
 99_workload_partitioning.yaml
 Install-config.yaml


### PR DESCRIPTION
use external parameter to replace the in-file variables.

$ ./00_extract_tools_from_release.sh 4.9.4
You are going to install OpenShift 4.9.4

$ ./02_generate_workloadpartitioning_config.sh
Run the script like ./02_generate_workloadpartitioning_config.sh <CPUSET>, for example ./02_generate_workloadpartitioning_config.sh 0-3,16-19

$./03_generate_inplacedns_config.sh 
Run the script like ./03_generate_inplacedns_config.sh <your SNO node IP>, for example: ./03_generate_inplacedns_config.sh 10.19.142.235
